### PR TITLE
rb_tree.h: fix insert()

### DIFF
--- a/include/rb_node.h
+++ b/include/rb_node.h
@@ -13,9 +13,9 @@ public:
 	RBNode *right_;
 	Color color_;
 
-	// RBNode() = default;
+	RBNode() = default;
 
-	RBNode(const T& value = 0, RBNode<T> *parent = nullptr, RBNode<T> *left= nullptr, RBNode<T> *right= nullptr, Color color = RED)
+	RBNode(const T& value, RBNode<T> *parent = nullptr, RBNode<T> *left= nullptr, RBNode<T> *right= nullptr, Color color = RED)
 	: value_(value), left_(left), right_(right), parent_(parent), color_(color)
 	{}
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -9,7 +9,7 @@
 template<typename T>
 void print_tree(std::ostream& os, const std::string& prefix, const RBNode<T> *node, bool is_left)
 {
-	if(node == nullptr)
+	if(node -> left_ == nullptr && node->right_ == nullptr)
 		return;
 
 	os << prefix;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -52,12 +52,12 @@ int main(void)
 	#if 1 // Create a tree using Insert
 		// 11, 2, 14, 1, 15, 7, 5, 8, 4
 		RBNode<int> *roots = new RBNode<int>(11);
-		RBNode<int> *l = new RBNode<int>(2);
+		RBNode<int> *l = new RBNode<int>(3);
 		RBNode<int> *ll = new RBNode<int>(1);
 		RBNode<int> *lr = new RBNode<int>(7);
 		RBNode<int> *lrl = new RBNode<int>(5);
 		RBNode<int> *lrr = new RBNode<int>(8);
-		RBNode<int> *r = new RBNode<int>(14);
+		RBNode<int> *r = new RBNode<int>(1);
 		RBNode<int> *rr = new RBNode<int>(15);
 		RBNode<int> *newNode = new RBNode<int>(4);
 
@@ -72,9 +72,12 @@ int main(void)
 		RBTree<int>::Iterator it_lrr = tree->insert(lrr);
 		RBTree<int>::Iterator it_new = tree->insert(newNode);
 		RBTree<int>::Iterator it_1 = tree->begin();
-
+		cout << *tree << tree;
+		RBTree<int> newtree = RBTree<int>(*tree);
+		cout << newtree << &newtree;
 		#if 0 // Test for level-order successors
-		
+
+
 		cout << *tree;
 		cout << "Levelorder successors!\n";
 		cout << it_lr;
@@ -127,7 +130,7 @@ int main(void)
 
 		#endif
 
-		#if 1 // Test for post-order successors
+		#if 0 // Test for post-order successors
 		tree->print_postorder();
 		cout << "Post-order successors!\n";
 		cout << it_lr;


### PR DESCRIPTION
The insert function seems to give segmentation faults everytime a skewed
tree is created (e.g., if nodes were inserted in the order - 11, 4, 2).

Turns out, these issues were majorly being created since leaf nodes would
point to nullptr instead of NIL(and even if they did point to NIL, NIL
was a nullptr, so there was no real effect).
Making NIL actually a node (albeit an empty one), and rewriting the insert
function appropriately fixes this issue.

Modify the RBNode constructors, so that default constructor is in play,
and if not, atleast the value of the node has to be passed to the ctor.

Remove tree_insert(), and rewrite insert() in line with the actually
correct, true CLRS explanation. insert() now uses the helper function
insert_fixup() instead.

Fixes: 29c4c56 ("RBTree: define the basic insert() function")
Signed-off-by: Anant Thazhemadam <anant.thazhemadam@gmail.com>